### PR TITLE
fix: remove duplicate bash tool check in pre_tool_use hook

### DIFF
--- a/.claude/hooks/pre_tool_use.py
+++ b/.claude/hooks/pre_tool_use.py
@@ -161,9 +161,6 @@ def main():
         
         if tool_name == 'Bash':
             command = tool_input.get('command', '')
-            
-            if tool_name == 'Bash':
-            command = tool_input.get('command', '')
         
         # Ensure log directory exists
         log_dir = Path.cwd() / 'logs'


### PR DESCRIPTION
## Summary
- Removed duplicate conditional check for 'Bash' tool name in the pre_tool_use.py hook
- Fixed redundant code that was checking for the same condition twice

## Details
The `pre_tool_use.py` hook had a duplicate check:
```python
if tool_name == 'Bash':
    command = tool_input.get('command', '')
```

This was appearing twice in the `main()` function, which could lead to confusion and potential bugs. This PR removes the duplicate check, keeping only one instance.

## Test plan
- [x] Verified that the pre_tool_use hook still functions correctly
- [x] Confirmed that Bash tool logging still works as expected
- [x] No other functionality is affected by this change

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logic to remove redundant checks, improving code clarity. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->